### PR TITLE
Upgrade framework version 6lts

### DIFF
--- a/samples/TradingBot/Program.cs
+++ b/samples/TradingBot/Program.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿#if NETCOREAPP3_1
+
+using System.IO;
 using System.Threading.Tasks;
 
 namespace TradingBot
@@ -13,3 +15,15 @@ namespace TradingBot
         }
     }
 }
+
+#endif
+
+#if NET6_0_OR_GREATER
+
+using TradingBot;
+
+var token = (await File.ReadAllTextAsync("token.txt")).Trim();
+await using var bot = new SandboxBot(token);
+await bot.StartAsync();
+
+#endif

--- a/samples/TradingBot/SandboxBot.cs
+++ b/samples/TradingBot/SandboxBot.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿#if NETCOREAPP3_1
+using System;
 using System.Threading.Tasks;
+#endif
 using Tinkoff.Trading.OpenApi.Models;
 using Tinkoff.Trading.OpenApi.Network;
 

--- a/samples/TradingBot/TradingBot.csproj
+++ b/samples/TradingBot/TradingBot.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/TradingBot/TradingBot.csproj
+++ b/samples/TradingBot/TradingBot.csproj
@@ -5,9 +5,10 @@
         <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.NETCore.App" Version="2.2.0" />
-    </ItemGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Tinkoff.Trading.OpenApi\Tinkoff.Trading.OpenApi.csproj" />

--- a/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
+++ b/src/Tinkoff.Trading.OpenApi/Tinkoff.Trading.OpenApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <Company>Tinkoff</Company>
         <PackageVersion>1.7.5</PackageVersion>
         <Title>Tinkoff Invest .NET SDK</Title>

--- a/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
+++ b/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
+++ b/tests/Tinkoff.Trading.OpenApi.Tests/Tinkoff.Trading.OpenApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
@@ -8,12 +8,17 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.core" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I propose to add targeting for .NET 6, which LTS version. I've prepared pull request for that. Also I've made other minor changes. Please review them, however I don't expecting that there would be a trouble. 

Commit in Tests package are disputable. There are two different version of the same package for different versions of the framework.